### PR TITLE
External types

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Array of patterns that will be matched against each entity's `name`. Matching en
 
 #### excludePaths: `(string | RegExp)[]`
 
-Array of patterns that will be matched against each file's path. Matching files will not be parsed and entities in those files will not appear in the output.
+Array of patterns that will be matched against each file's path. Matching files _will be_ parsed but entities in those files _will not_ appear in the output.
 
 #### ignoreDefinitions: `boolean = false`
 

--- a/src/documentation.ts
+++ b/src/documentation.ts
@@ -133,12 +133,12 @@ export default class Documentation {
     }
 
     private filterEntry = (entry: IInterfaceEntry) => {
-        const { excludeNames = [], excludePaths = [] } = this.options;
+        const { excludeNames, excludePaths } = this.options;
         return testNoMatches(entry.name, excludeNames) && testNoMatches(entry.fileName, excludePaths);
     }
 }
 
 /** Returns true if the value matches exactly none of the patterns. */
-function testNoMatches(value: string, patterns: (string | RegExp)[]) {
+function testNoMatches(value: string, patterns: (string | RegExp)[] = []) {
     return patterns.every((pattern) => value.match(pattern as string) == null);
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,5 +1,6 @@
 export interface IDocEntry {
     documentation?: string;
+    fileName?: string;
     inheritedFrom?: string;
     name?: string;
     type?: string;
@@ -15,5 +16,4 @@ export interface IPropertyEntry extends IDocEntry {
 export interface IInterfaceEntry extends IDocEntry {
     extends?: string[];
     properties?: IPropertyEntry[];
-    fileName?: string;
 }

--- a/test/fixtures/external.ts
+++ b/test/fixtures/external.ts
@@ -1,0 +1,6 @@
+import * as React from "react";
+
+export interface IReactProps {
+    onClick: React.MouseEventHandler;
+    submenu: React.ReactChild;
+}

--- a/test/fixtures/interface.ts
+++ b/test/fixtures/interface.ts
@@ -7,7 +7,10 @@ export interface IInterface {
     disabled?: boolean;
 
     /** external type */
-    fancy?: Element;
+    fancy?: HTMLElement;
+
+    /** non-primitive type */
+    lastEdited: Date;
 }
 
 export interface IChildInterface extends IInterface, HTMLElement {

--- a/typings.json
+++ b/typings.json
@@ -4,6 +4,7 @@
   "globalDependencies": {
     "chai": "registry:dt/chai#3.4.0+20160317120654",
     "mocha": "registry:dt/mocha#2.2.5+20160317120654",
-    "node": "registry:dt/node#4.0.0+20160330064709"
+    "node": "registry:dt/node#4.0.0+20160330064709",
+    "react": "registry:dt/react#0.14.0+20160817201227"
   }
 }


### PR DESCRIPTION
support for external types!

previously, types defined in external libraries (such as `typings/` or even `lib.d.ts`) would come out as `any`.
this was resolved by including `fileName` information in every entry and filtering on `excludePaths` as the very last step, instead of as the very first step (so excluded paths wouldn't even be compiled).

cc @themadcreator