### PR TITLE
rename ignoreDefinitions to includeDefinitionFiles

### DIFF
--- a/src/documentation.ts
+++ b/src/documentation.ts
@@ -10,17 +10,18 @@ export interface IDocumentationOptions {
     excludePaths?: Array<string | RegExp>;
 
     /**
-     * Whether `.d.ts` files should always be ignored.
-     * @default false
-     */
-    ignoreDefinitions?: boolean;
-
-    /**
      * Whether built-in properties for basic types should appear in the output (such as String.prototype.toString).
      * Defaults to `false` because these properties tend to pollute output for no benefit.
      * @default false
      */
     includeBasicTypeProperties?: boolean;
+
+    /**
+     * Whether symbols from `.d.ts` files should be included in the output.
+     * Enabling this can get very messy as everything from `@types` will be included.
+     * @default false
+     */
+    includeDefinitionFiles?: boolean;
 }
 
 export default class Documentation {
@@ -43,8 +44,8 @@ export default class Documentation {
     constructor(program: ts.Program, options: IDocumentationOptions = {}) {
         this.program = program;
         this.options = {
-            ignoreDefinitions: false,
             includeBasicTypeProperties: false,
+            includeDefinitionFiles: false,
             ...options,
         };
     }
@@ -71,7 +72,7 @@ export default class Documentation {
 
         // Visit every sourceFile in the program
         for (const sourceFile of this.program.getSourceFiles()) {
-            if (this.options.ignoreDefinitions && /\.d\.ts$/.test(sourceFile.fileName)) { continue; }
+            if (!this.options.includeDefinitionFiles && /\.d\.ts$/.test(sourceFile.fileName)) { continue; }
             // Walk the tree to search for classes
             ts.forEachChild(sourceFile, visit);
         }

--- a/test/spec.ts
+++ b/test/spec.ts
@@ -17,7 +17,7 @@ describe("TypeScript Documentation", function(this: Mocha.ISuiteCallbackContext)
     });
 
     it("returns empty array for empty files", () => {
-        const entries = Documentation.fromFiles([], { noLib: true }, { ignoreDefinitions: true });
+        const entries = Documentation.fromFiles([], { noLib: true });
         expect(entries).to.be.empty;
     });
 
@@ -31,6 +31,12 @@ describe("TypeScript Documentation", function(this: Mocha.ISuiteCallbackContext)
     it("excludeNames excludes named items", () => {
         const excludeDocs = fixture("interface.ts", { excludeNames: ["IInterface"] });
         expect(excludeDocs.map((i) => i.name)).to.not.contain("IInterface");
+    });
+
+    it("includeDefinitionFiles=true exposes @types symbols", () => {
+        const includeDocs = Documentation.fromFiles([], { noLib: true }, { includeDefinitionFiles: true });
+        // no source files of our own so everything exposed should come from @types .d.ts files
+        includeDocs.map((entry) => expect(entry.fileName).to.match(/\.d\.ts$/));
     });
 
     describe("for interfaces", () => {
@@ -78,7 +84,6 @@ describe("TypeScript Documentation", function(this: Mocha.ISuiteCallbackContext)
         it("includeBasicTypeProperties=false has zero string properties", () => {
             const filepath = path.join(__dirname, "fixtures", "const.ts");
             const basicDocs = Documentation.fromFiles([filepath], { noLib: false }, {
-                ignoreDefinitions: true,
                 includeBasicTypeProperties: false,
             });
             expect(basicDocs[1].properties).to.be.empty; // FILE_NAME
@@ -88,14 +93,13 @@ describe("TypeScript Documentation", function(this: Mocha.ISuiteCallbackContext)
         it("includeBasicTypeProperties=true includes tons of string properties", () => {
             const filepath = path.join(__dirname, "fixtures", "const.ts");
             const basicDocs = Documentation.fromFiles([filepath], { noLib: false }, {
-                ignoreDefinitions: true,
                 includeBasicTypeProperties: true,
             });
             expect(basicDocs[1].properties.map((p) => p.name)).to.contain.members(["toString", "lastIndexOf", "match"]);
         });
     });
 
-    describe.only("jsdoc @tags", () => {
+    describe("jsdoc @tags", () => {
         let entry: IInterfaceEntry;
         before(() => entry = getEntry(fixture("jsdoc.ts"), "IJsDocInterface"));
 

--- a/tslint.json
+++ b/tslint.json
@@ -1,3 +1,13 @@
 {
-  "extends": ["tslint:latest"]
+  "extends": [
+    "tslint:latest"
+  ],
+  "rules": {
+    "ban": [
+      true,
+      [ "Object", "assign", "use TS2.1 object spread { ...a, ...b }" ],
+      [ "describe", "only" ],
+      [ "it", "only" ]
+    ]
+  }
 }


### PR DESCRIPTION
and invert semantics.
now the default `false` value means .d.ts files will be excluded from the output by default, because i was always enabling it.